### PR TITLE
fix: cannot import by commonjs type (fixes: #11)

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var webdriverConfig = {
     hostname: 'fe.nhnent.com',
     port: 4444,
@@ -133,6 +135,7 @@ module.exports = function(config) {
         singleRun: true
     };
 
+    /* eslint-disable */
     setConfig(defaultConfig, process.env.KARMA_SERVER);
     config.set(defaultConfig);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tui-code-snippet",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "TOAST UI Utility: CodeSnippet",
   "main": "dist/tui-code-snippet.js",
   "scripts": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,11 +31,6 @@ module.exports = {
         preLoaders: [
             {
                 test: /\.js$/,
-                exclude: /(test|bower_components|node_modules)/,
-                loader: 'istanbul-instrumenter'
-            },
-            {
-                test: /\.js$/,
                 exclude: /(bower_components|node_modules)/,
                 loader: 'eslint-loader'
             }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,9 +19,7 @@ module.exports = {
     eslint: {
         failOnError: isProduction
     },
-    entry: {
-        'entry': './src/js/index.js'
-    },
+    entry: './src/js/index.js',
     output: {
         library: ['tui', 'util'],
         libraryTarget: 'umd',


### PR DESCRIPTION
fixes: #11 - cannot import `code-snippet` by commonjs type

* due to invalid webpack configuration - `entry` option
* remove `istanbul-instrumenter` from webpack loader
    * before: transformed file is added in bundle file
    * after: source code only
