### PR TITLE
chore: reduce call of sendHostname

### DIFF
--- a/src/js/request.js
+++ b/src/js/request.js
@@ -20,10 +20,17 @@ function sendHostname(applicationId) {
     var hostname = location.hostname;
     var hitType = 'event';
     var trackingId = 'UA-115377265-9';
+    var applicationKeyForStorage = 'TOAST UI ' + applicationId + ' for ' + hostname + ': Statistics';
+    var alreadySentForThisApplication = window.localStorage.getItem(applicationKeyForStorage);
 
     // skip only if the flag is defined and is set to false explicitly
-    if (!type.isUndefined(window.tui) && window.tui.usageStatistics === false) {
+    if ((!type.isUndefined(window.tui) && window.tui.usageStatistics === false)
+        || alreadySentForThisApplication) {
         return;
+    }
+
+    if (!alreadySentForThisApplication) {
+        window.localStorage.setItem(applicationKeyForStorage, true);
     }
 
     setTimeout(function() {


### PR DESCRIPTION
To reduce `sendHostname()` call on every running web page, I record a kind of long using localStorage. The key is `TOAST UI ${applicationid} for ${hostname}: Statistics`. For example "TOAST UI Calendar for ui.toast.com: Statistics". The value is just `true` which is not nullable.

Expect that
* Just send it only one time per browser.
* All TOAST UI Family can separately send it with own `applicationId` and `hostname` even if a web page has several TOAST UI application.
* Can still get statistics properly.