### PR TITLE
fix: don't send usage statistics if tui.usageStatistics is false

### DIFF
--- a/src/js/request.js
+++ b/src/js/request.js
@@ -87,6 +87,9 @@ function sendHostname(appName, trackingId) {
  * });
  */
 function imagePing(url, trackingInfo) {
+    if (!type.isUndefined(window.tui) && window.tui.usageStatistics === false) {
+        return;
+    }
     var queryString = collection.map(object.keys(trackingInfo), function(key, index) {
         var startWith = index === 0 ? '' : '&';
 


### PR DESCRIPTION
The check within the `sendHostname` function is not enough. Data was still leaking to Google Analytics. See #22.

I added another check right at the beginning of `imagePing`. This will ensure that no data will be transmitted to Google Analytics if `window.tui.usageStatistics` is set to `false`. 

This PR fixes #22.